### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Inject `/my/param` as `$MY_PARAM` and `/other/param` as `$OTHER_PARAM`:
 steps:
   - command: echo "/my/param ${MY_PARAM}"
     plugins:
-      unbounce/aws-ssm#v1.0.0:
-        region: us-west-2
-        parameters:
-          MY_PARAM: /my/param
-          OTHER_PARAM: /other/param
+      - unbounce/aws-ssm#v1.0.0:
+          region: us-west-2
+          parameters:
+            MY_PARAM: /my/param
+            OTHER_PARAM: /other/param
 ```
 
 Region is set to `AWS_DEFAULT_REGION` by default, but can be overriden to a different value to `region:`


### PR DESCRIPTION
Hi @pauloancheta! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.